### PR TITLE
Colosseum Custom Starters Move Randomization

### DIFF
--- a/Randomizer/Shufflers/Helpers.cs
+++ b/Randomizer/Shufflers/Helpers.cs
@@ -77,7 +77,7 @@ namespace Randomizer.Shufflers
         }
 
 
-        private static void UpdateMoves(AbstractRNG random, RandomMoveSetOptions options, IPokemonInstance pokemon, ExtractedGame extractedGame)
+        public static void UpdateMoves(AbstractRNG random, RandomMoveSetOptions options, IPokemonInstance pokemon, ExtractedGame extractedGame)
         {
             var moveSetCount = options.ForceFourMoves ? 4 : pokemon.Moves.Where(m => m > 0).Count();
 

--- a/Randomizer/Shufflers/StaticPokemonShuffler.cs
+++ b/Randomizer/Shufflers/StaticPokemonShuffler.cs
@@ -152,6 +152,7 @@ namespace Randomizer.Shufflers
         private static void RandomizeStarters(AbstractRNG random, ShuffleSettings shuffleSettings, ExtractedGame extractedGame, int[] pickedShadows, IGiftPokemon starter1, IGiftPokemon starter2 = null)
         {
             var settings = shuffleSettings.RandomizerSettings.StaticPokemonShufflerSettings;
+            var moveSetOptions = shuffleSettings.RandomizerSettings.TeamShufflerSettings.MoveSetOptions;
             Logger.Log("=============================== Starters ===============================\n\n");
 
             Logger.Log($"Your new starter is:\n");
@@ -160,6 +161,9 @@ namespace Randomizer.Shufflers
                 starter1.Pokemon = (ushort?)extractedGame.PokemonList.FirstOrDefault(p => p.Name.ToLower() == settings.Starter1.ToLower())?.Index ?? starter1.Pokemon;
                 if (starter2 != null)
                     starter2.Pokemon = (ushort?)extractedGame.PokemonList.FirstOrDefault(p => p.Name.ToLower() == settings.Starter2.ToLower())?.Index ?? starter2.Pokemon;
+
+                Helpers.UpdateMoves(random, moveSetOptions, starter1, extractedGame);
+                Helpers.UpdateMoves(random, moveSetOptions, starter2, extractedGame);
             }
             else
             {


### PR DESCRIPTION
Fixed an issue where starter Pokemon moves in colosseum would not be randomized corresponding to the move randomization settings.